### PR TITLE
Memoize view_context in renderer

### DIFF
--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -89,7 +89,11 @@ module ActionView
     #
     # Override this method in a module to change the default behavior.
     def view_context
-      view_context_class.new(lookup_context, view_assigns, self)
+      @_view_context ||= new_view_context
+    end
+
+    def new_view_context
+      @_view_context = view_context_class.new(lookup_context, view_assigns, self)
     end
 
     # Returns an object that is able to render templates.
@@ -108,7 +112,7 @@ module ActionView
       def _render_template(options)
         variant = options.delete(:variant)
         assigns = options.delete(:assigns)
-        context = view_context
+        context = new_view_context
 
         context.assign assigns if assigns
         lookup_context.variants = variant if variant


### PR DESCRIPTION
In ViewComponent we're seeing multiple instances of the view context
being created due to relying on `view_context.controller.view_context`
to provide helper methods to the component. This causes issues when
using memoized helper methods due to each component instantiating its
own `view_context` when helpers are used.

This fixes the issue by creating a single `view_context` in controllers
and memoizing it, so each call to `view_context` will return the same
instance, keeping already defined ivars preserved.

Co-authored-by: Ian C. Anderson <ian@iancanderson.com>

(opened here to hopefully run tests)

